### PR TITLE
Codex-generated pull request

### DIFF
--- a/server/api/blog/like.post.ts
+++ b/server/api/blog/like.post.ts
@@ -12,15 +12,9 @@ export default defineEventHandler(async (event) => {
 
   await storage.setItem(likedKey, isLiked)
 
-  if (likes) {
-    if (isLiked) {
-      await storage.setItem(likesKey, likes + 1)
-    } else {
-      await storage.setItem(likesKey, likes - 1)
-    }
-  } else {
-    await storage.setItem(likesKey, 1)
-  }
+  const currentLikes = likes ?? 0
+  const nextLikes = isLiked ? currentLikes + 1 : Math.max(0, currentLikes - 1)
+  await storage.setItem(likesKey, nextLikes)
 
   return true
 })

--- a/server/api/calendar/index.get.ts
+++ b/server/api/calendar/index.get.ts
@@ -2,6 +2,17 @@ import type { BlogCollectionItem } from '@nuxt/content'
 import { serverSupabaseClient } from '#supabase/server'
 import dayjs from 'dayjs'
 
+interface QQCalendarRow {
+  tid: string
+  name: string
+  content: string
+  created_time: number
+  createtime?: string
+  pic?: unknown
+  video?: unknown
+  commentlist?: unknown
+}
+
 export interface CalendarEvent {
   id: string
   source: 'blog' | 'qq'
@@ -56,7 +67,7 @@ export default defineEventHandler(async (event) => {
         .gte('created_time', startTs)
         .lte('created_time', endTs)
         .order('created_time', { ascending: true })
-      return data ?? []
+      return (data ?? []) as QQCalendarRow[]
     })(),
   ])
 
@@ -77,9 +88,10 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  for (const row of qqResult as any[]) {
-    const ts = row.created_time ? row.created_time * 1000 : Date.now()
-    const date = dayjs.unix(row.created_time).format('YYYY-M-D')
+  for (const row of qqResult) {
+    const createdTime = row.created_time ?? Math.floor(Date.now() / 1000)
+    const ts = createdTime * 1000
+    const date = dayjs.unix(createdTime).format('YYYY-M-D')
     events.push({
       id: row.tid,
       source: 'qq',

--- a/server/api/qq/import.post.ts
+++ b/server/api/qq/import.post.ts
@@ -3,26 +3,36 @@ import { serverSupabaseClient } from '#supabase/server'
 import list from '~~/server/data/data.json'
 import { Result } from '~~/server/utils/result'
 
+type ImportRecord = {
+  tid: string
+  name: string | null
+  content: string | null
+  source_name: string | null
+  commentlist: QQContentComment[] | null
+  video: unknown[] | null
+  pic: Pic[] | null
+}
+
 export default defineEventHandler(async (event) => {
-  const client = await serverSupabaseClient<any>(event)
-  let result: any
+  const client = await serverSupabaseClient(event)
   try {
-    result = await Promise.all(
+    const result = await Promise.all(
       list.map(async (item) => {
-        const record = {
+        const record: ImportRecord = {
           tid: item.tid,
           name: item.name ?? null,
           content: item.content ?? null,
           source_name: item.source_name ?? null,
           commentlist: (item.commentlist as QQContentComment[]) ?? null,
-          video: item.video ?? null,
+          video: (item.video as unknown[]) ?? null,
           pic: (item.pic as Pic[]) ?? null,
         }
         return await client.from('qq_content').update(record).eq('tid', item.tid).select()
       }),
     )
+    return Result.success(result)
   } catch (error) {
-    return Result.fail(500, error as string)
+    const message = error instanceof Error ? error.message : String(error)
+    return Result.fail(500, message)
   }
-  return Result.success(result)
 })

--- a/server/api/qq/list.get.ts
+++ b/server/api/qq/list.get.ts
@@ -3,6 +3,23 @@ import type { QQContentItem } from '~~/shared/types/qq'
 import { serverSupabaseClient } from '#supabase/server'
 import consola from 'consola'
 
+interface QQContentRow {
+  commentlist: string | QQContentItem['commentlist']
+  pic: string | QQContentItem['pic']
+  video: string | QQContentItem['video']
+  [key: string]: unknown
+}
+
+function parseJSONField<T>(value: string | T | null | undefined): T | null {
+  if (!value) return null
+  if (typeof value !== 'string') return value
+  try {
+    return JSON.parse(value) as T
+  } catch {
+    return null
+  }
+}
+
 export default defineEventHandler(async (event) => {
   const client = await serverSupabaseClient(event)
   const {
@@ -16,16 +33,22 @@ export default defineEventHandler(async (event) => {
 
   const offset = (currentNumber - 1) * sizeNumber
 
-  let searchSingleResult: any = null
+  let searchSingleResult: QQContentItem | null = null
   if (tid) {
     const { data, error } = await client.from('qq_content').select('*').eq('tid', tid).single()
 
     if (error) {
       consola.error(error)
-      createError({ statusCode: 500, statusMessage: error.message })
+      throw createError({ statusCode: 500, statusMessage: error.message })
     }
 
-    searchSingleResult = data
+    searchSingleResult = {
+      ...(data as QQContentRow),
+      commentlist: parseJSONField<QQContentItem['commentlist']>((data as QQContentRow).commentlist),
+      pic: parseJSONField<QQContentItem['pic']>((data as QQContentRow).pic),
+      video: parseJSONField<QQContentItem['video']>((data as QQContentRow).video),
+      isSearchSingle: true,
+    } as QQContentItem
     searchSingleResult.isSearchSingle = true
   }
 
@@ -39,7 +62,7 @@ export default defineEventHandler(async (event) => {
 
   if (error) {
     consola.error(error)
-    createError({ statusCode: 500, statusMessage: error.message })
+    throw createError({ statusCode: 500, statusMessage: error.message })
   }
 
   if (!data || data.length === 0) {
@@ -51,11 +74,12 @@ export default defineEventHandler(async (event) => {
   const transformedData = [searchSingleResult, ...data]
     .filter((item) => item !== null)
     .map((item) => {
+      const row = item as QQContentRow
       return {
         ...item,
-        commentlist: item.commentlist ? JSON.parse(item.commentlist) : null,
-        pic: item.pic ? JSON.parse(item.pic) : null,
-        video: item.video ? JSON.parse(item.video) : null,
+        commentlist: parseJSONField<QQContentItem['commentlist']>(row.commentlist),
+        pic: parseJSONField<QQContentItem['pic']>(row.pic),
+        video: parseJSONField<QQContentItem['video']>(row.video),
       } as QQContentItem
     })
 

--- a/server/api/search/homeSearch.post.ts
+++ b/server/api/search/homeSearch.post.ts
@@ -1,5 +1,32 @@
 import type { HomeSearchBody } from '~~/server/types/search'
+import type { QQContentItem } from '~~/shared/types/qq'
+import type { BlogCollectionItem } from '@nuxt/content'
 import consola from 'consola'
+
+type HomeSearchResultItem = {
+  keyword: string
+  source: 'qq' | 'blog'
+  id: string
+  path: string
+}
+
+function mapToSearchResult(item: QQContentItem | BlogCollectionItem): HomeSearchResultItem {
+  if ('tid' in item) {
+    return {
+      keyword: item.content,
+      source: 'qq',
+      id: item.tid,
+      path: `/qq?tid=${item.tid}`,
+    }
+  }
+
+  return {
+    keyword: item.title,
+    source: 'blog',
+    id: item.id ?? '',
+    path: item.path,
+  }
+}
 
 export default defineEventHandler(async (event) => {
   const body = await readBody<HomeSearchBody>(event)
@@ -10,24 +37,16 @@ export default defineEventHandler(async (event) => {
   }
 
   try {
-    const contentResult = await queryCollection(event, 'blog')
-      .where('title', 'LIKE', `%${keyword || ''}%`)
-      .all()
+    const contentResult = await queryCollection(event, 'blog').where('title', 'LIKE', `%${keyword}%`).all()
 
-    const qqResult = await $fetch('/api/qq/list', { query: { content: keyword } })
+    const qqResult = await $fetch<{ data: QQContentItem[] }>('/api/qq/list', { query: { content: keyword } })
 
-    const searchResults = [...qqResult.data, ...contentResult].map((item: any) => {
-      return {
-        keyword: item?.tid ? item.content : item.title,
-        source: item?.tid ? 'qq' : 'blog',
-        id: item?.tid ? item.tid : item.id,
-        path: item?.tid ? `/qq?tid=${item.tid}` : item.path,
-      }
-    })
+    const searchResults = [...qqResult.data, ...contentResult].map((item) => mapToSearchResult(item))
 
     return Result.success(searchResults)
   } catch (error) {
     consola.error(error)
-    Result.fail(500, error as string)
+    const message = error instanceof Error ? error.message : String(error)
+    return Result.fail(500, message)
   }
 })

--- a/server/utils/result.ts
+++ b/server/utils/result.ts
@@ -3,7 +3,7 @@ export class Result<T> {
   message: string
   data: T | null
 
-  constructor(code: number, message: string, data: T) {
+  constructor(code: number, message: string, data: T | null) {
     this.code = code
     this.message = message
     this.data = data

--- a/shared/types/qq.ts
+++ b/shared/types/qq.ts
@@ -16,7 +16,7 @@ export interface QQContentItem {
   pic?: Pic[] | null
   tid: string
   uin?: number | null
-  video?: any[] | null
+  video?: unknown[] | null
   isSearchSingle?: boolean
 }
 


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d8c5566088325a56647f0f55bdb2e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple API endpoints and changes response/error behavior (e.g., JSON parsing, thrown errors, like count clamping), which could affect clients and data correctness if assumptions differ.
> 
> **Overview**
> Improves several server endpoints with safer defaults, stricter typing, and more consistent error handling.
> 
> `/api/blog/like` now computes the next like count from `likes ?? 0` and clamps decrements at 0 to prevent negative counts.
> 
> QQ-related APIs are hardened: calendar fetching uses typed Supabase rows and robust `created_time` fallback; `qq/list` safely parses `commentlist`/`pic`/`video` JSON fields (returning `null` on bad JSON) and now *throws* on Supabase errors; `qq/import` returns `Result.success` from inside the try and standardizes error messages.
> 
> Home search refactors result mapping into `mapToSearchResult`, adds typed `$fetch` of `qq/list`, and ensures failures return `Result.fail` with a proper message. Also updates `Result` to allow `null` data and narrows `QQContentItem.video` from `any[]` to `unknown[]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 377a46077a3e4aa7f519d5509d777eb8d5266cd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->